### PR TITLE
Starting point for GameSetup - screen structure, with basic styling

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -10,6 +10,7 @@ import Landing from './src/screens/landing/Landing';
 import {NavigationContainer} from '@react-navigation/native';
 import {createNativeStackNavigator} from '@react-navigation/native-stack';
 import GameSetup from './src/screens/game-setup/GameSetup';
+import {Colors} from 'react-native/Libraries/NewAppScreen';
 
 const Stack = createNativeStackNavigator();
 
@@ -22,6 +23,10 @@ function App(): JSX.Element {
           component={GameSetup}
           options={{
             title: 'New game',
+            headerStyle: {
+              backgroundColor: Colors.primary,
+            },
+            headerTintColor: Colors.white,
           }}
         />
         <Stack.Screen name="Landing" component={Landing} />

--- a/App.tsx
+++ b/App.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 import Landing from './src/screens/landing/Landing';
 import {NavigationContainer} from '@react-navigation/native';
 import {createNativeStackNavigator} from '@react-navigation/native-stack';
+import GameSetup from './src/screens/game-setup/GameSetup';
 
 const Stack = createNativeStackNavigator();
 
@@ -16,6 +17,13 @@ function App(): JSX.Element {
   return (
     <NavigationContainer>
       <Stack.Navigator>
+        <Stack.Screen
+          name="GameSetup"
+          component={GameSetup}
+          options={{
+            title: 'New game',
+          }}
+        />
         <Stack.Screen name="Landing" component={Landing} />
       </Stack.Navigator>
     </NavigationContainer>

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@babel/preset-env": "^7.20.0",
         "@babel/runtime": "^7.20.0",
         "@react-native-community/eslint-config": "^3.0.0",
+        "@testing-library/react-native": "^11.5.1",
         "@tsconfig/react-native": "^2.0.3",
         "@types/jest": "^29.2.6",
         "@types/react": "^18.0.27",
@@ -2376,11 +2377,11 @@
       }
     },
     "node_modules/@jest/schemas": {
-      "version": "29.0.0",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.0.0.tgz",
-      "integrity": "sha512-3Ab5HgYIIAnS0HjqJHQYZS+zXc4tUmTmBH3z83ajI6afXp8X3ZtdLX+nXx+I7LNkJD7uN9LAVhgnjDgZa2z0kA==",
+      "version": "29.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.4.0.tgz",
+      "integrity": "sha512-0E01f/gOZeNTG76i5eWWSupvSHaIINrTie7vCyjiYFKgzNdyEGd12BUv4oNBFHOqlHDbtoJi3HrQ38KCC90NsQ==",
       "dependencies": {
-        "@sinclair/typebox": "^0.24.1"
+        "@sinclair/typebox": "^0.25.16"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -4477,9 +4478,9 @@
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.24.51",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.51.tgz",
-      "integrity": "sha512-1P1OROm/rdubP5aFDSZQILU0vrLCJ4fvHt6EoqHEM+2D/G5MK3bIaymUKLit8Js9gbns5UyJnkP/TZROLw4tUA=="
+      "version": "0.25.21",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.21.tgz",
+      "integrity": "sha512-gFukHN4t8K4+wVC+ECqeqwzBDeFeTzBXroBTqE6vcWrQGbEUpHO7LYdG0f4xnvYq4VOEwITSlHlp0JBAIFMS/g=="
     },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.6",
@@ -4495,6 +4496,26 @@
       "integrity": "sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==",
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "node_modules/@testing-library/react-native": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-native/-/react-native-11.5.1.tgz",
+      "integrity": "sha512-+yIXBQxbAL7ca2J/rKGGonCLMvj11pGoiw4Pp66dlYsKPauYrxesIs3W0UHMNLafSYshnMsrbYx3YOtOFgumiw==",
+      "dev": true,
+      "dependencies": {
+        "pretty-format": "^29.4.0"
+      },
+      "peerDependencies": {
+        "jest": ">=28.0.0",
+        "react": ">=16.8.0",
+        "react-native": ">=0.59",
+        "react-test-renderer": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "jest": {
+          "optional": true
+        }
       }
     },
     "node_modules/@tsconfig/react-native": {
@@ -12623,11 +12644,11 @@
       }
     },
     "node_modules/pretty-format": {
-      "version": "29.3.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.3.1.tgz",
-      "integrity": "sha512-FyLnmb1cYJV8biEIiRyzRFvs2lry7PPIvOqKVe1GCUEYg4YGmlx1qG9EJNMxArYm7piII4qb8UV1Pncq5dxmcg==",
+      "version": "29.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.4.1.tgz",
+      "integrity": "sha512-dt/Z761JUVsrIKaY215o1xQJBGlSmTx/h4cSqXqjHLnU1+Kt+mavVE7UgqJJO5ukx5HjSswHfmXz4LjS2oIJfg==",
       "dependencies": {
-        "@jest/schemas": "^29.0.0",
+        "@jest/schemas": "^29.4.0",
         "ansi-styles": "^5.0.0",
         "react-is": "^18.0.0"
       },
@@ -16534,11 +16555,11 @@
       }
     },
     "@jest/schemas": {
-      "version": "29.0.0",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.0.0.tgz",
-      "integrity": "sha512-3Ab5HgYIIAnS0HjqJHQYZS+zXc4tUmTmBH3z83ajI6afXp8X3ZtdLX+nXx+I7LNkJD7uN9LAVhgnjDgZa2z0kA==",
+      "version": "29.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.4.0.tgz",
+      "integrity": "sha512-0E01f/gOZeNTG76i5eWWSupvSHaIINrTie7vCyjiYFKgzNdyEGd12BUv4oNBFHOqlHDbtoJi3HrQ38KCC90NsQ==",
       "requires": {
-        "@sinclair/typebox": "^0.24.1"
+        "@sinclair/typebox": "^0.25.16"
       }
     },
     "@jest/source-map": {
@@ -18110,9 +18131,9 @@
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "@sinclair/typebox": {
-      "version": "0.24.51",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.51.tgz",
-      "integrity": "sha512-1P1OROm/rdubP5aFDSZQILU0vrLCJ4fvHt6EoqHEM+2D/G5MK3bIaymUKLit8Js9gbns5UyJnkP/TZROLw4tUA=="
+      "version": "0.25.21",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.21.tgz",
+      "integrity": "sha512-gFukHN4t8K4+wVC+ECqeqwzBDeFeTzBXroBTqE6vcWrQGbEUpHO7LYdG0f4xnvYq4VOEwITSlHlp0JBAIFMS/g=="
     },
     "@sinonjs/commons": {
       "version": "1.8.6",
@@ -18128,6 +18149,15 @@
       "integrity": "sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==",
       "requires": {
         "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@testing-library/react-native": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-native/-/react-native-11.5.1.tgz",
+      "integrity": "sha512-+yIXBQxbAL7ca2J/rKGGonCLMvj11pGoiw4Pp66dlYsKPauYrxesIs3W0UHMNLafSYshnMsrbYx3YOtOFgumiw==",
+      "dev": true,
+      "requires": {
+        "pretty-format": "^29.4.0"
       }
     },
     "@tsconfig/react-native": {
@@ -24168,11 +24198,11 @@
       }
     },
     "pretty-format": {
-      "version": "29.3.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.3.1.tgz",
-      "integrity": "sha512-FyLnmb1cYJV8biEIiRyzRFvs2lry7PPIvOqKVe1GCUEYg4YGmlx1qG9EJNMxArYm7piII4qb8UV1Pncq5dxmcg==",
+      "version": "29.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.4.1.tgz",
+      "integrity": "sha512-dt/Z761JUVsrIKaY215o1xQJBGlSmTx/h4cSqXqjHLnU1+Kt+mavVE7UgqJJO5ukx5HjSswHfmXz4LjS2oIJfg==",
       "requires": {
-        "@jest/schemas": "^29.0.0",
+        "@jest/schemas": "^29.4.0",
         "ansi-styles": "^5.0.0",
         "react-is": "^18.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "android": "react-native run-android",
     "ios": "react-native run-ios",
+    "ios-sim": "react-native run-ios --simulator 6E8E5934-54FE-43E9-88DA-C35559E2EFD7",
     "lint": "eslint .",
     "start": "react-native start",
     "test": "jest"

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@babel/preset-env": "^7.20.0",
     "@babel/runtime": "^7.20.0",
     "@react-native-community/eslint-config": "^3.0.0",
+    "@testing-library/react-native": "^11.5.1",
     "@tsconfig/react-native": "^2.0.3",
     "@types/jest": "^29.2.6",
     "@types/react": "^18.0.27",

--- a/src/colors/Colors.ts
+++ b/src/colors/Colors.ts
@@ -2,4 +2,5 @@ export const Colors = {
   primary: '#1B2533',
   secondary: '#52B3EC',
   white: '#FFFFFF',
+  secondaryDisabled: '#0C4A6E',
 };

--- a/src/colors/Colors.ts
+++ b/src/colors/Colors.ts
@@ -1,0 +1,5 @@
+export const Colors = {
+  primary: '#1B2533',
+  secondary: '#52B3EC',
+  white: '#FFFFFF',
+};

--- a/src/components/BaseTouchable/BaseTouchable.style.ts
+++ b/src/components/BaseTouchable/BaseTouchable.style.ts
@@ -1,0 +1,7 @@
+import {StyleSheet} from 'react-native';
+
+export const styles = StyleSheet.create({
+  baseTouchableContainer: {
+    flexDirection: 'row',
+  },
+});

--- a/src/components/BaseTouchable/BaseTouchable.style.ts
+++ b/src/components/BaseTouchable/BaseTouchable.style.ts
@@ -1,7 +1,18 @@
 import {StyleSheet} from 'react-native';
+import {Colors} from '../../colors/Colors';
 
 export const styles = StyleSheet.create({
   baseTouchableContainer: {
     flexDirection: 'row',
+  },
+  button: {
+    backgroundColor: Colors.secondary,
+    padding: 12,
+    marginRight: 12,
+    borderRadius: 8,
+    marginTop: 16,
+  },
+  buttonText: {
+    color: Colors.white,
   },
 });

--- a/src/components/BaseTouchable/BaseTouchable.style.ts
+++ b/src/components/BaseTouchable/BaseTouchable.style.ts
@@ -15,4 +15,11 @@ export const styles = StyleSheet.create({
   buttonText: {
     color: Colors.white,
   },
+  isDisabled: {
+    marginTop: 16,
+    padding: 12,
+    borderRadius: 8,
+    marginRight: 12,
+    backgroundColor: 'rgba(82, 179, 236, 0.3)',
+  },
 });

--- a/src/components/BaseTouchable/BaseTouchable.style.ts
+++ b/src/components/BaseTouchable/BaseTouchable.style.ts
@@ -20,6 +20,6 @@ export const styles = StyleSheet.create({
     padding: 12,
     borderRadius: 8,
     marginRight: 12,
-    backgroundColor: 'rgba(82, 179, 236, 0.3)',
+    backgroundColor: Colors.secondaryDisabled,
   },
 });

--- a/src/components/BaseTouchable/BaseTouchable.tsx
+++ b/src/components/BaseTouchable/BaseTouchable.tsx
@@ -13,7 +13,8 @@ const BaseTouchable = (props: BaseTouchableProps) => {
       <TouchableOpacity
         style={button.isDisabled ? styles.isDisabled : styles.button}
         key={index}
-        onPress={(props.buttons[index] as BaseTouchableButtons).onPress}>
+        onPress={(props.buttons[index] as BaseTouchableButtons).onPress}
+        testID={button.testId}>
         <Text style={styles.buttonText}>
           {(button as BaseTouchableButtons).text}
         </Text>

--- a/src/components/BaseTouchable/BaseTouchable.tsx
+++ b/src/components/BaseTouchable/BaseTouchable.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {SafeAreaView, Text, TouchableOpacity, View} from 'react-native';
 import {styles} from './BaseTouchable.style';
+
 export type BaseTouchableProps = {
   buttons: Array<BaseTouchableButtons>;
 };
@@ -15,9 +16,12 @@ const BaseTouchable = (props: BaseTouchableProps) => {
   props.buttons.forEach(function (button, index) {
     buttons.push(
       <TouchableOpacity
+        style={styles.button}
         key={index}
         onPress={(props.buttons[index] as BaseTouchableButtons).onPress}>
-        <Text>{(button as BaseTouchableButtons).text}</Text>
+        <Text style={styles.buttonText}>
+          {(button as BaseTouchableButtons).text}
+        </Text>
       </TouchableOpacity>,
     );
   });

--- a/src/components/BaseTouchable/BaseTouchable.tsx
+++ b/src/components/BaseTouchable/BaseTouchable.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import {SafeAreaView, Text, TouchableOpacity, View} from 'react-native';
+import {styles} from './BaseTouchable.style';
+export type BaseTouchableProps = {
+  buttons: Array<BaseTouchableButtons>;
+};
+
+export type BaseTouchableButtons = {
+  text: string;
+  onPress: () => void;
+};
+
+const BaseTouchable = (props: BaseTouchableProps) => {
+  let buttons: [object?] = [];
+  props.buttons.forEach(function (button, index) {
+    buttons.push(
+      <TouchableOpacity
+        key={index}
+        onPress={(props.buttons[index] as BaseTouchableButtons).onPress}>
+        <Text>{(button as BaseTouchableButtons).text}</Text>
+      </TouchableOpacity>,
+    );
+  });
+
+  return (
+    <>
+      <SafeAreaView>
+        {/* @ts-ignore */}
+        <View style={styles.baseTouchableContainer}>{buttons}</View>
+      </SafeAreaView>
+    </>
+  );
+};
+
+export default BaseTouchable;

--- a/src/components/BaseTouchable/BaseTouchable.tsx
+++ b/src/components/BaseTouchable/BaseTouchable.tsx
@@ -1,15 +1,10 @@
 import React from 'react';
 import {SafeAreaView, Text, TouchableOpacity, View} from 'react-native';
 import {styles} from './BaseTouchable.style';
-
-export type BaseTouchableProps = {
-  buttons: Array<BaseTouchableButtons>;
-};
-
-export type BaseTouchableButtons = {
-  text: string;
-  onPress: () => void;
-};
+import {
+  BaseTouchableButtons,
+  BaseTouchableProps,
+} from '../../types/base-touchable/BaseTouchable';
 
 const BaseTouchable = (props: BaseTouchableProps) => {
   let buttons: [object?] = [];

--- a/src/components/BaseTouchable/BaseTouchable.tsx
+++ b/src/components/BaseTouchable/BaseTouchable.tsx
@@ -11,7 +11,7 @@ const BaseTouchable = (props: BaseTouchableProps) => {
   props.buttons.forEach(function (button, index) {
     buttons.push(
       <TouchableOpacity
-        style={styles.button}
+        style={button.isDisabled ? styles.isDisabled : styles.button}
         key={index}
         onPress={(props.buttons[index] as BaseTouchableButtons).onPress}>
         <Text style={styles.buttonText}>

--- a/src/components/PrimaryButton/PrimaryButton.tsx
+++ b/src/components/PrimaryButton/PrimaryButton.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import {Text, TouchableOpacity} from 'react-native';
+import {globalStyle} from '../../globals/styles/Global.style';
+
+export type PrimaryButtonProps = {
+  text: string;
+  onPress: () => void;
+  disabled: boolean;
+};
+
+const PrimaryButton = (props: PrimaryButtonProps) => {
+  return (
+    <TouchableOpacity
+      style={
+        props.disabled
+          ? globalStyle.primaryButtonDisabled
+          : globalStyle.primaryButtonActive
+      }
+      disabled={props.disabled}
+      onPress={props.onPress}>
+      <Text style={globalStyle.primaryButtonText}>{props.text}</Text>
+    </TouchableOpacity>
+  );
+};
+
+export default PrimaryButton;

--- a/src/components/ScoringTouchable/ScoringTouchable.tsx
+++ b/src/components/ScoringTouchable/ScoringTouchable.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import {Text, TouchableOpacity, View} from 'react-native';
+
+const ScoringTouchable = () => {
+  return (
+    <>
+      <View>
+        <TouchableOpacity>
+          <Text>To 11</Text>
+        </TouchableOpacity>
+        <TouchableOpacity>
+          <Text>To 15</Text>
+        </TouchableOpacity>
+        <TouchableOpacity>
+          <Text>To 9</Text>
+        </TouchableOpacity>
+      </View>
+    </>
+  );
+};
+
+export default ScoringTouchable;

--- a/src/components/ScoringTouchable/ScoringTouchable.tsx
+++ b/src/components/ScoringTouchable/ScoringTouchable.tsx
@@ -1,18 +1,20 @@
 import React from 'react';
 import {Text, TouchableOpacity, View} from 'react-native';
 
-const ScoringTouchable = () => {
+type ScoringTouchableProps = {
+  onAmericanScoringPressed: () => void | undefined;
+  onEnglishScoringPressed: () => void | undefined;
+};
+
+const ScoringTouchable = (props: ScoringTouchableProps) => {
   return (
     <>
       <View>
-        <TouchableOpacity>
-          <Text>To 11</Text>
+        <TouchableOpacity onPressIn={props.onAmericanScoringPressed}>
+          <Text>American Scoring</Text>
         </TouchableOpacity>
-        <TouchableOpacity>
-          <Text>To 15</Text>
-        </TouchableOpacity>
-        <TouchableOpacity>
-          <Text>To 9</Text>
+        <TouchableOpacity onPressIn={props.onEnglishScoringPressed}>
+          <Text>English Scoring</Text>
         </TouchableOpacity>
       </View>
     </>

--- a/src/globals/styles/Global.style.ts
+++ b/src/globals/styles/Global.style.ts
@@ -9,4 +9,23 @@ export const globalStyle = StyleSheet.create({
   containerPadding: {
     margin: 12,
   },
+  primaryButtonDisabled: {
+    backgroundColor: Colors.secondaryDisabled,
+    padding: 12,
+    margin: 12,
+    borderRadius: 8,
+  },
+  primaryButtonActive: {
+    backgroundColor: Colors.secondary,
+    padding: 12,
+    margin: 12,
+    borderRadius: 8,
+  },
+  primaryButtonText: {
+    textAlign: 'center',
+    color: Colors.white,
+    fontWeight: 'bold',
+    paddingTop: 6,
+    paddingBottom: 6,
+  },
 });

--- a/src/globals/styles/Global.style.ts
+++ b/src/globals/styles/Global.style.ts
@@ -1,0 +1,12 @@
+import {StyleSheet} from 'react-native';
+import {Colors} from '../../colors/Colors';
+
+export const globalStyle = StyleSheet.create({
+  textHeading: {
+    color: Colors.white,
+    fontSize: 24,
+  },
+  containerPadding: {
+    margin: 12,
+  },
+});

--- a/src/screens/game-setup/GameSetup.style.ts
+++ b/src/screens/game-setup/GameSetup.style.ts
@@ -1,0 +1,18 @@
+import {StyleSheet} from 'react-native';
+import {Colors} from '../../colors/Colors';
+
+export const styles = StyleSheet.create({
+  gameScreenContainer: {
+    backgroundColor: Colors.primary,
+    height: '100%',
+  },
+  gameSetupViewContainer: {
+    margin: 12,
+  },
+  playerNameField: {
+    backgroundColor: Colors.white,
+    height: 48,
+    marginTop: 16,
+    borderRadius: 8,
+  },
+});

--- a/src/screens/game-setup/GameSetup.test.tsx
+++ b/src/screens/game-setup/GameSetup.test.tsx
@@ -11,6 +11,8 @@ describe('<GameSetup />', () => {
   const btn_americanScoring = 'btn-americanScoring';
   const btn_englishScoring = 'btn-englishScoring';
   const btn_ninePoints = 'btn-9Points';
+  const btn_11Points = 'btn-11Points';
+  const btn_15Points = 'btn-15Points';
 
   it('renders correctly', () => {
     renderer.create(<GameSetup />);
@@ -32,7 +34,25 @@ describe('<GameSetup />', () => {
       );
     });
 
-    it('only gives the options for 11 points and 15 points', () => {});
+    it('only gives the options for 11 points and 15 points', () => {
+      const {getByTestId} = render(<GameSetup />);
+
+      const americanScoringButton = getByTestId('btn-americanScoring');
+      const elevenPointsButton = getByTestId(btn_11Points);
+      const fifteenPointsButton = getByTestId(btn_15Points);
+      const ninePointsButton = getByTestId(btn_ninePoints);
+
+      expect(americanScoringButton).not.toBeNull();
+      expect(ninePointsButton).not.toBeNull();
+      expect(elevenPointsButton).not.toBeNull();
+      expect(fifteenPointsButton).not.toBeNull();
+
+      fireEvent.press(americanScoringButton);
+
+      expect(ninePointsButton.props.style.backgroundColor).toEqual(
+        disabledButtonStyle,
+      );
+    });
 
     it('allows the user to switch to english scoring', () => {
       const {getByTestId} = render(<GameSetup />);
@@ -52,6 +72,28 @@ describe('<GameSetup />', () => {
   });
 
   describe('English scoring', () => {
-    it('disables 15 & 11 points when selecting english scoring', () => {});
+    it('disables 15 & 11 points when selecting english scoring', () => {
+      const {getByTestId} = render(<GameSetup />);
+
+      const englishScoringButton = getByTestId('btn-englishScoring');
+      const elevenPointsButton = getByTestId(btn_11Points);
+      const fifteenPointsButton = getByTestId(btn_15Points);
+      const ninePointsButton = getByTestId(btn_ninePoints);
+
+      expect(englishScoringButton).not.toBeNull();
+      expect(ninePointsButton).not.toBeNull();
+      expect(elevenPointsButton).not.toBeNull();
+      expect(fifteenPointsButton).not.toBeNull();
+
+      fireEvent.press(englishScoringButton);
+
+      expect(fifteenPointsButton.props.style.backgroundColor).toEqual(
+        disabledButtonStyle,
+      );
+
+      expect(elevenPointsButton.props.style.backgroundColor).toEqual(
+        disabledButtonStyle,
+      );
+    });
   });
 });

--- a/src/screens/game-setup/GameSetup.test.tsx
+++ b/src/screens/game-setup/GameSetup.test.tsx
@@ -1,0 +1,30 @@
+import 'react-native';
+import React from 'react';
+
+// Note: test renderer must be required after react-native.
+import renderer from 'react-test-renderer';
+import {fireEvent, render} from '@testing-library/react-native';
+import GameSetup from './GameSetup';
+
+describe('<GameSetup />', () => {
+  const disabledButtonStyle = 'rgba(82, 179, 236, 0.3)';
+
+  it('renders correctly', () => {
+    renderer.create(<GameSetup />);
+  });
+
+  it('disables 9 points when selecting american scoring', () => {
+    const {getByTestId} = render(<GameSetup />);
+
+    const americanScoringButton = getByTestId('btn-americanScoring');
+    const ninePointsButton = getByTestId('btn-9Points');
+    expect(americanScoringButton).not.toBeNull();
+    expect(ninePointsButton).not.toBeNull();
+
+    fireEvent.press(americanScoringButton);
+
+    expect(ninePointsButton.props.style.backgroundColor).toEqual(
+      disabledButtonStyle,
+    );
+  });
+});

--- a/src/screens/game-setup/GameSetup.test.tsx
+++ b/src/screens/game-setup/GameSetup.test.tsx
@@ -8,23 +8,50 @@ import GameSetup from './GameSetup';
 
 describe('<GameSetup />', () => {
   const disabledButtonStyle = 'rgba(82, 179, 236, 0.3)';
+  const btn_americanScoring = 'btn-americanScoring';
+  const btn_englishScoring = 'btn-englishScoring';
+  const btn_ninePoints = 'btn-9Points';
 
   it('renders correctly', () => {
     renderer.create(<GameSetup />);
   });
 
-  it('disables 9 points when selecting american scoring', () => {
-    const {getByTestId} = render(<GameSetup />);
+  describe('American scoring', () => {
+    it('disables 9 points when selecting american scoring', () => {
+      const {getByTestId} = render(<GameSetup />);
 
-    const americanScoringButton = getByTestId('btn-americanScoring');
-    const ninePointsButton = getByTestId('btn-9Points');
-    expect(americanScoringButton).not.toBeNull();
-    expect(ninePointsButton).not.toBeNull();
+      const americanScoringButton = getByTestId('btn-americanScoring');
+      const ninePointsButton = getByTestId(btn_ninePoints);
+      expect(americanScoringButton).not.toBeNull();
+      expect(ninePointsButton).not.toBeNull();
 
-    fireEvent.press(americanScoringButton);
+      fireEvent.press(americanScoringButton);
 
-    expect(ninePointsButton.props.style.backgroundColor).toEqual(
-      disabledButtonStyle,
-    );
+      expect(ninePointsButton.props.style.backgroundColor).toEqual(
+        disabledButtonStyle,
+      );
+    });
+
+    it('only gives the options for 11 points and 15 points', () => {});
+
+    it('allows the user to switch to english scoring', () => {
+      const {getByTestId} = render(<GameSetup />);
+
+      const americanScoringButton = getByTestId(btn_americanScoring);
+      fireEvent.press(americanScoringButton);
+      expect(americanScoringButton.props.style.backgroundColor).not.toEqual(
+        disabledButtonStyle,
+      );
+
+      const englishScoring = getByTestId(btn_englishScoring);
+      fireEvent.press(englishScoring);
+      expect(americanScoringButton.props.style.backgroundColor).toEqual(
+        disabledButtonStyle,
+      );
+    });
+  });
+
+  describe('English scoring', () => {
+    it('disables 15 & 11 points when selecting english scoring', () => {});
   });
 });

--- a/src/screens/game-setup/GameSetup.test.tsx
+++ b/src/screens/game-setup/GameSetup.test.tsx
@@ -5,9 +5,10 @@ import React from 'react';
 import renderer from 'react-test-renderer';
 import {fireEvent, render} from '@testing-library/react-native';
 import GameSetup from './GameSetup';
+import {Colors} from '../../colors/Colors';
 
 describe('<GameSetup />', () => {
-  const disabledButtonStyle = 'rgba(82, 179, 236, 0.3)';
+  const disabledButtonStyle = Colors.secondaryDisabled;
   const btn_americanScoring = 'btn-americanScoring';
   const btn_englishScoring = 'btn-englishScoring';
   const btn_ninePoints = 'btn-9Points';

--- a/src/screens/game-setup/GameSetup.tsx
+++ b/src/screens/game-setup/GameSetup.tsx
@@ -7,17 +7,11 @@ import {
   TextInput,
   View,
 } from 'react-native';
-import {AmericanScoring, EnglishScoring} from '../../types/scoring/ScoringType';
+import ScoringTouchable from '../../components/ScoringTouchable/ScoringTouchable';
 
 const GameSetup = () => {
   const [playerAName, setPlayerAName] = useState('');
   const [playerBName, setPlayerBName] = useState('');
-
-  const americanScoring: AmericanScoring = true;
-  const englishScoring: EnglishScoring = false;
-  const [scoringMethod, setScoringMethod] = useState<
-    AmericanScoring | EnglishScoring
-  >(americanScoring);
 
   const [bestOfGames, setBestOfGames] = useState(false);
   const [pointsPerGame, setPointsPerGame] = useState(true);
@@ -44,16 +38,7 @@ const GameSetup = () => {
         <View>
           <Text>Scoring method</Text>
           <View>
-            <Switch
-              value={scoringMethod}
-              onValueChange={newValue => {
-                if (newValue === americanScoring) {
-                  setScoringMethod(americanScoring);
-                } else {
-                  setScoringMethod(englishScoring);
-                }
-              }}
-            />
+            <ScoringTouchable />
           </View>
         </View>
         <View>

--- a/src/screens/game-setup/GameSetup.tsx
+++ b/src/screens/game-setup/GameSetup.tsx
@@ -1,6 +1,8 @@
 import React, {useState} from 'react';
 import {Button, SafeAreaView, Text, TextInput, View} from 'react-native';
 import BaseTouchable from '../../components/BaseTouchable/BaseTouchable';
+import {styles} from './GameSetup.style';
+import {globalStyle} from '../../globals/styles/Global.style';
 
 const GameSetup = () => {
   const [playerAName, setPlayerAName] = useState('');
@@ -8,9 +10,11 @@ const GameSetup = () => {
 
   return (
     <>
-      <SafeAreaView>
-        <View>
+      <SafeAreaView style={styles.gameScreenContainer}>
+        <View style={styles.gameSetupViewContainer}>
+          <Text style={globalStyle.textHeading}>Players</Text>
           <TextInput
+            style={styles.playerNameField}
             placeholder={'Player A Name'}
             onChangeText={updatedName => {
               setPlayerAName(updatedName);
@@ -18,6 +22,7 @@ const GameSetup = () => {
             value={playerAName}
           />
           <TextInput
+            style={styles.playerNameField}
             placeholder={'Player B Name'}
             onChangeText={updatedName => {
               setPlayerBName(updatedName);
@@ -25,8 +30,8 @@ const GameSetup = () => {
             value={playerBName}
           />
         </View>
-        <View>
-          <Text>Scoring method</Text>
+        <View style={globalStyle.containerPadding}>
+          <Text style={globalStyle.textHeading}>Scoring method</Text>
           <View>
             <BaseTouchable
               buttons={[
@@ -36,8 +41,8 @@ const GameSetup = () => {
             />
           </View>
         </View>
-        <View>
-          <Text>Best of (3 / 5) games</Text>
+        <View style={globalStyle.containerPadding}>
+          <Text style={globalStyle.textHeading}>Best of (3 / 5) games</Text>
           <BaseTouchable
             buttons={[
               {
@@ -45,14 +50,14 @@ const GameSetup = () => {
                 onPress: () => {},
               },
               {
-                text: 'Best of 3',
+                text: 'Best of 5',
                 onPress: () => {},
               },
             ]}
           />
         </View>
-        <View>
-          <Text>Points per game</Text>
+        <View style={globalStyle.containerPadding}>
+          <Text style={globalStyle.textHeading}>Points per game</Text>
           <BaseTouchable
             buttons={[
               {text: '15 points', onPress: () => {}},

--- a/src/screens/game-setup/GameSetup.tsx
+++ b/src/screens/game-setup/GameSetup.tsx
@@ -1,20 +1,10 @@
 import React, {useState} from 'react';
-import {
-  Button,
-  SafeAreaView,
-  Switch,
-  Text,
-  TextInput,
-  View,
-} from 'react-native';
+import {Button, SafeAreaView, Text, TextInput, View} from 'react-native';
 import ScoringTouchable from '../../components/ScoringTouchable/ScoringTouchable';
 
 const GameSetup = () => {
   const [playerAName, setPlayerAName] = useState('');
   const [playerBName, setPlayerBName] = useState('');
-
-  const [bestOfGames, setBestOfGames] = useState(false);
-  const [pointsPerGame, setPointsPerGame] = useState(true);
 
   return (
     <>
@@ -38,26 +28,23 @@ const GameSetup = () => {
         <View>
           <Text>Scoring method</Text>
           <View>
-            <ScoringTouchable />
+            <ScoringTouchable
+              onEnglishScoringPressed={() => {
+                console.log('english scoring');
+              }}
+              onAmericanScoringPressed={() => {
+                console.log('american scoring');
+              }}
+            />
           </View>
         </View>
         <View>
           <Text>Best of (3 / 5) games</Text>
-          <Switch
-            value={bestOfGames}
-            onValueChange={updatedBestOfGames => {
-              setBestOfGames(updatedBestOfGames);
-            }}
-          />
+          {/* //TODO: build number of games component */}
         </View>
         <View>
           <Text>Points per game</Text>
-          <Switch
-            value={pointsPerGame}
-            onValueChange={updatedPointsPerGame => {
-              setPointsPerGame(updatedPointsPerGame);
-            }}
-          />
+          {/* //TODO: build points per game component*/}
         </View>
         <View>
           <Button title={'Start game'} />

--- a/src/screens/game-setup/GameSetup.tsx
+++ b/src/screens/game-setup/GameSetup.tsx
@@ -1,6 +1,6 @@
 import React, {useState} from 'react';
 import {Button, SafeAreaView, Text, TextInput, View} from 'react-native';
-import ScoringTouchable from '../../components/ScoringTouchable/ScoringTouchable';
+import BaseTouchable from '../../components/BaseTouchable/BaseTouchable';
 
 const GameSetup = () => {
   const [playerAName, setPlayerAName] = useState('');
@@ -28,23 +28,38 @@ const GameSetup = () => {
         <View>
           <Text>Scoring method</Text>
           <View>
-            <ScoringTouchable
-              onEnglishScoringPressed={() => {
-                console.log('english scoring');
-              }}
-              onAmericanScoringPressed={() => {
-                console.log('american scoring');
-              }}
+            <BaseTouchable
+              buttons={[
+                {text: 'American scoring', onPress: () => {}},
+                {text: 'English scoring', onPress: () => {}},
+              ]}
             />
           </View>
         </View>
         <View>
           <Text>Best of (3 / 5) games</Text>
-          {/* //TODO: build number of games component */}
+          <BaseTouchable
+            buttons={[
+              {
+                text: 'Best of 3',
+                onPress: () => {},
+              },
+              {
+                text: 'Best of 3',
+                onPress: () => {},
+              },
+            ]}
+          />
         </View>
         <View>
           <Text>Points per game</Text>
-          {/* //TODO: build points per game component*/}
+          <BaseTouchable
+            buttons={[
+              {text: '15 points', onPress: () => {}},
+              {text: '11 points', onPress: () => {}},
+              {text: '9 points', onPress: () => {}},
+            ]}
+          />
         </View>
         <View>
           <Button title={'Start game'} />

--- a/src/screens/game-setup/GameSetup.tsx
+++ b/src/screens/game-setup/GameSetup.tsx
@@ -1,0 +1,67 @@
+import React, {useState} from 'react';
+import { Button, SafeAreaView, Switch, Text, TextInput, View } from "react-native";
+
+const GameSetup = () => {
+  const [playerAName, setPlayerAName] = useState('');
+  const [playerBName, setPlayerBName] = useState('');
+  const [scoringMethod, setScoringMethod] = useState(false);
+  const [bestOfGames, setBestOfGames] = useState(false);
+  const [pointsPerGame, setPointsPerGame] = useState(false);
+
+  return (
+    <>
+      <SafeAreaView>
+        <View>
+          <TextInput
+            placeholder={'Player A Name'}
+            onChangeText={updatedName => {
+              setPlayerAName(updatedName);
+            }}
+            value={playerAName}
+          />
+          <TextInput
+            placeholder={'Player B Name'}
+            onChangeText={updatedName => {
+              setPlayerBName(updatedName);
+            }}
+            value={playerBName}
+          />
+        </View>
+        <View>
+          <Text>Scoring method</Text>
+          <View>
+            <Switch
+              value={scoringMethod}
+              onValueChange={newValue => {
+                setScoringMethod(newValue);
+              }}
+            />
+          </View>
+        </View>
+        <View>
+          <Text>Best of (3 / 5) games</Text>
+          <Switch
+            value={bestOfGames}
+            onValueChange={updatedBestOfGames => {
+              setBestOfGames(updatedBestOfGames);
+            }}
+          />
+        </View>
+        <View>
+          <Text>Points per game</Text>
+          <Switch
+            value={pointsPerGame}
+            onValueChange={updatedPointsPerGame => {
+              setPointsPerGame(updatedPointsPerGame);
+            }}
+          />
+        </View>
+        <View>
+          <Button title={'Start game'} />
+        </View>
+      </SafeAreaView>
+    </>
+  );
+};
+
+export default GameSetup;

--- a/src/screens/game-setup/GameSetup.tsx
+++ b/src/screens/game-setup/GameSetup.tsx
@@ -3,10 +3,36 @@ import {Button, SafeAreaView, Text, TextInput, View} from 'react-native';
 import BaseTouchable from '../../components/BaseTouchable/BaseTouchable';
 import {styles} from './GameSetup.style';
 import {globalStyle} from '../../globals/styles/Global.style';
+import {ScoringMethod} from '../../types/scoring/ScoringMethod';
+import {BestOfGames} from '../../types/games/BestOfGames';
+import {PointsPerGame} from '../../types/points-per-game/PointsPerGame';
 
 const GameSetup = () => {
   const [playerAName, setPlayerAName] = useState('');
   const [playerBName, setPlayerBName] = useState('');
+  const [scoringMethod, setScoringMethod] = useState<ScoringMethod>();
+  const [bestOfGames, setBestOfGames] = useState<BestOfGames>();
+  const [pointsPerGame, setPointsPerGame] = useState<PointsPerGame>();
+
+  function pointsTo15() {
+    return pointsPerGame === PointsPerGame.PointsTo15;
+  }
+
+  const americanTo15 = () => {
+    return isAmericanScoring() && pointsTo15();
+  };
+
+  function isEnglishScoring() {
+    return scoringMethod === ScoringMethod.EnglishScoring;
+  }
+
+  function americanTo11() {
+    return isAmericanScoring() && pointsPerGame === PointsPerGame.PointsTo11;
+  }
+
+  function isAmericanScoring() {
+    return scoringMethod === ScoringMethod.AmericanScoring;
+  }
 
   return (
     <>
@@ -35,8 +61,20 @@ const GameSetup = () => {
           <View>
             <BaseTouchable
               buttons={[
-                {text: 'American scoring', onPress: () => {}},
-                {text: 'English scoring', onPress: () => {}},
+                {
+                  text: 'American scoring',
+                  onPress: () => {
+                    setScoringMethod(ScoringMethod.AmericanScoring);
+                  },
+                  isDisabled: isEnglishScoring(),
+                },
+                {
+                  text: 'English scoring',
+                  onPress: () => {
+                    setScoringMethod(ScoringMethod.EnglishScoring);
+                  },
+                  isDisabled: isAmericanScoring(),
+                },
               ]}
             />
           </View>
@@ -47,11 +85,17 @@ const GameSetup = () => {
             buttons={[
               {
                 text: 'Best of 3',
-                onPress: () => {},
+                onPress: () => {
+                  setBestOfGames(BestOfGames.BestOf3);
+                },
+                isDisabled: bestOfGames === BestOfGames.BestOf5,
               },
               {
                 text: 'Best of 5',
-                onPress: () => {},
+                onPress: () => {
+                  setBestOfGames(BestOfGames.BestOf5);
+                },
+                isDisabled: bestOfGames === BestOfGames.BestOf3,
               },
             ]}
           />
@@ -60,9 +104,27 @@ const GameSetup = () => {
           <Text style={globalStyle.textHeading}>Points per game</Text>
           <BaseTouchable
             buttons={[
-              {text: '15 points', onPress: () => {}},
-              {text: '11 points', onPress: () => {}},
-              {text: '9 points', onPress: () => {}},
+              {
+                text: '15 points',
+                onPress: () => {
+                  setPointsPerGame(PointsPerGame.PointsTo15);
+                },
+                isDisabled: isEnglishScoring() || americanTo11(),
+              },
+              {
+                text: '11 points',
+                onPress: () => {
+                  setPointsPerGame(PointsPerGame.PointsTo11);
+                },
+                isDisabled: isEnglishScoring() || americanTo15(),
+              },
+              {
+                text: '9 points',
+                onPress: () => {
+                  setPointsPerGame(PointsPerGame.PointsTo9);
+                },
+                isDisabled: isAmericanScoring(),
+              },
             ]}
           />
         </View>

--- a/src/screens/game-setup/GameSetup.tsx
+++ b/src/screens/game-setup/GameSetup.tsx
@@ -67,6 +67,7 @@ const GameSetup = () => {
                     setScoringMethod(ScoringMethod.AmericanScoring);
                   },
                   isDisabled: isEnglishScoring(),
+                  testId: 'btn-americanScoring',
                 },
                 {
                   text: 'English scoring',
@@ -74,6 +75,7 @@ const GameSetup = () => {
                     setScoringMethod(ScoringMethod.EnglishScoring);
                   },
                   isDisabled: isAmericanScoring(),
+                  testId: 'btn-englishScoring',
                 },
               ]}
             />
@@ -89,6 +91,7 @@ const GameSetup = () => {
                   setBestOfGames(BestOfGames.BestOf3);
                 },
                 isDisabled: bestOfGames === BestOfGames.BestOf5,
+                testId: 'btn-bestOf3',
               },
               {
                 text: 'Best of 5',
@@ -96,6 +99,7 @@ const GameSetup = () => {
                   setBestOfGames(BestOfGames.BestOf5);
                 },
                 isDisabled: bestOfGames === BestOfGames.BestOf3,
+                testId: 'btn-bestOf5',
               },
             ]}
           />
@@ -110,6 +114,7 @@ const GameSetup = () => {
                   setPointsPerGame(PointsPerGame.PointsTo15);
                 },
                 isDisabled: isEnglishScoring() || americanTo11(),
+                testId: 'btn-15Points',
               },
               {
                 text: '11 points',
@@ -117,6 +122,7 @@ const GameSetup = () => {
                   setPointsPerGame(PointsPerGame.PointsTo11);
                 },
                 isDisabled: isEnglishScoring() || americanTo15(),
+                testId: 'btn-11Points',
               },
               {
                 text: '9 points',
@@ -124,6 +130,7 @@ const GameSetup = () => {
                   setPointsPerGame(PointsPerGame.PointsTo9);
                 },
                 isDisabled: isAmericanScoring(),
+                testId: 'btn-9Points',
               },
             ]}
           />

--- a/src/screens/game-setup/GameSetup.tsx
+++ b/src/screens/game-setup/GameSetup.tsx
@@ -14,25 +14,25 @@ const GameSetup = () => {
   const [bestOfGames, setBestOfGames] = useState<BestOfGames>();
   const [pointsPerGame, setPointsPerGame] = useState<PointsPerGame>();
 
-  function pointsTo15() {
+  const pointsTo15 = () => {
     return pointsPerGame === PointsPerGame.PointsTo15;
-  }
+  };
 
   const americanTo15 = () => {
     return isAmericanScoring() && pointsTo15();
   };
 
-  function isEnglishScoring() {
+  const isEnglishScoring = () => {
     return scoringMethod === ScoringMethod.EnglishScoring;
-  }
+  };
 
-  function americanTo11() {
+  const americanTo11 = () => {
     return isAmericanScoring() && pointsPerGame === PointsPerGame.PointsTo11;
-  }
+  };
 
-  function isAmericanScoring() {
+  const isAmericanScoring = () => {
     return scoringMethod === ScoringMethod.AmericanScoring;
-  }
+  };
 
   return (
     <>

--- a/src/screens/game-setup/GameSetup.tsx
+++ b/src/screens/game-setup/GameSetup.tsx
@@ -1,12 +1,26 @@
 import React, {useState} from 'react';
-import { Button, SafeAreaView, Switch, Text, TextInput, View } from "react-native";
+import {
+  Button,
+  SafeAreaView,
+  Switch,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import {AmericanScoring, EnglishScoring} from '../../types/scoring/ScoringType';
 
 const GameSetup = () => {
   const [playerAName, setPlayerAName] = useState('');
   const [playerBName, setPlayerBName] = useState('');
-  const [scoringMethod, setScoringMethod] = useState(false);
+
+  const americanScoring: AmericanScoring = true;
+  const englishScoring: EnglishScoring = false;
+  const [scoringMethod, setScoringMethod] = useState<
+    AmericanScoring | EnglishScoring
+  >(americanScoring);
+
   const [bestOfGames, setBestOfGames] = useState(false);
-  const [pointsPerGame, setPointsPerGame] = useState(false);
+  const [pointsPerGame, setPointsPerGame] = useState(true);
 
   return (
     <>
@@ -33,7 +47,12 @@ const GameSetup = () => {
             <Switch
               value={scoringMethod}
               onValueChange={newValue => {
-                setScoringMethod(newValue);
+                if (newValue === americanScoring) {
+                  console.log(newValue);
+                  setScoringMethod(americanScoring);
+                } else {
+                  setScoringMethod(englishScoring);
+                }
               }}
             />
           </View>

--- a/src/screens/game-setup/GameSetup.tsx
+++ b/src/screens/game-setup/GameSetup.tsx
@@ -1,11 +1,12 @@
 import React, {useState} from 'react';
-import {Button, SafeAreaView, Text, TextInput, View} from 'react-native';
+import {SafeAreaView, Text, TextInput, View} from 'react-native';
 import BaseTouchable from '../../components/BaseTouchable/BaseTouchable';
 import {styles} from './GameSetup.style';
 import {globalStyle} from '../../globals/styles/Global.style';
 import {ScoringMethod} from '../../types/scoring/ScoringMethod';
 import {BestOfGames} from '../../types/games/BestOfGames';
 import {PointsPerGame} from '../../types/points-per-game/PointsPerGame';
+import PrimaryButton from '../../components/PrimaryButton/PrimaryButton';
 
 const GameSetup = () => {
   const [playerAName, setPlayerAName] = useState('');
@@ -32,6 +33,30 @@ const GameSetup = () => {
 
   const isAmericanScoring = () => {
     return scoringMethod === ScoringMethod.AmericanScoring;
+  };
+
+  const playerNamesFilledIn = () => {
+    return playerAName !== '' && playerBName !== '';
+  };
+
+  const canStartGame = () => {
+    switch (scoringMethod) {
+      case ScoringMethod.AmericanScoring:
+        return (
+          playerNamesFilledIn() &&
+          (bestOfGames === BestOfGames.BestOf3 ||
+            bestOfGames === BestOfGames.BestOf5) &&
+          (pointsPerGame === PointsPerGame.PointsTo11 ||
+            pointsPerGame === PointsPerGame.PointsTo15)
+        );
+      case ScoringMethod.EnglishScoring:
+        return (
+          playerNamesFilledIn() &&
+          (bestOfGames === BestOfGames.BestOf3 ||
+            bestOfGames === BestOfGames.BestOf5) &&
+          pointsPerGame === PointsPerGame.PointsTo9
+        );
+    }
   };
 
   return (
@@ -136,7 +161,11 @@ const GameSetup = () => {
           />
         </View>
         <View>
-          <Button title={'Start game'} />
+          <PrimaryButton
+            disabled={!canStartGame()}
+            text={'Start game'}
+            onPress={() => {}}
+          />
         </View>
       </SafeAreaView>
     </>

--- a/src/screens/game-setup/GameSetup.tsx
+++ b/src/screens/game-setup/GameSetup.tsx
@@ -48,7 +48,6 @@ const GameSetup = () => {
               value={scoringMethod}
               onValueChange={newValue => {
                 if (newValue === americanScoring) {
-                  console.log(newValue);
                   setScoringMethod(americanScoring);
                 } else {
                   setScoringMethod(englishScoring);

--- a/src/types/base-touchable/BaseTouchable.tsx
+++ b/src/types/base-touchable/BaseTouchable.tsx
@@ -6,4 +6,5 @@ export type BaseTouchableButtons = {
   text: string;
   onPress: () => void;
   isDisabled: boolean | undefined;
+  testId: string;
 };

--- a/src/types/base-touchable/BaseTouchable.tsx
+++ b/src/types/base-touchable/BaseTouchable.tsx
@@ -5,4 +5,5 @@ export type BaseTouchableProps = {
 export type BaseTouchableButtons = {
   text: string;
   onPress: () => void;
+  isDisabled: boolean | undefined;
 };

--- a/src/types/base-touchable/BaseTouchable.tsx
+++ b/src/types/base-touchable/BaseTouchable.tsx
@@ -1,0 +1,8 @@
+export type BaseTouchableProps = {
+  buttons: Array<BaseTouchableButtons>;
+};
+
+export type BaseTouchableButtons = {
+  text: string;
+  onPress: () => void;
+};

--- a/src/types/games/BestOfGames.ts
+++ b/src/types/games/BestOfGames.ts
@@ -1,0 +1,4 @@
+export enum BestOfGames {
+  BestOf3,
+  BestOf5,
+}

--- a/src/types/points-per-game/PointsPerGame.ts
+++ b/src/types/points-per-game/PointsPerGame.ts
@@ -1,0 +1,5 @@
+export enum PointsPerGame {
+  PointsTo9,
+  PointsTo11,
+  PointsTo15,
+}

--- a/src/types/scoring/ScoringMethod.tsx
+++ b/src/types/scoring/ScoringMethod.tsx
@@ -1,0 +1,4 @@
+export enum ScoringMethod {
+  AmericanScoring,
+  EnglishScoring,
+}

--- a/src/types/scoring/ScoringType.tsx
+++ b/src/types/scoring/ScoringType.tsx
@@ -1,0 +1,2 @@
+export type AmericanScoring = true;
+export type EnglishScoring = false;

--- a/src/types/scoring/ScoringType.tsx
+++ b/src/types/scoring/ScoringType.tsx
@@ -1,2 +1,0 @@
-export type AmericanScoring = true;
-export type EnglishScoring = false;


### PR DESCRIPTION
## Whats changed in this PR?

### 2023-02-07: Start button styling and test left to implement before merge.

### 2023-02-05: Started adding test suite for Game setup

### 2023-02-01: Created a BaseComponent that allows me to quickly create selections for points, games, scoring method. Still no styling at this point. Up next is logic implementation for combinations of scoring method and points.

Android
![Screenshot_1675297812](https://user-images.githubusercontent.com/3097647/216201620-311cc986-bfa2-4e1f-b958-8610bcf4ab01.png)

iOS
![Simulator Screen Shot - iPhone 14 Pro - 2023-02-02 at 00 30 08](https://user-images.githubusercontent.com/3097647/216201671-ef443fa4-b8d7-410f-9ff6-7138ca2f6ddc.png)


### 2023-01-29 : Switches aren't cutting it
- Removed the switches in favour of using a custom component that will with a bit more thinking facilitate the UI and business logic for scoring method, points per game and games per match. 
![Screenshot 2023-01-29 at 23 58 56](https://user-images.githubusercontent.com/3097647/215363543-fabcbb21-09c7-40c7-b493-5db31f55f8ea.png)
![Screenshot 2023-01-29 at 23 58 58](https://user-images.githubusercontent.com/3097647/215363545-399bc067-f73c-4367-a39d-446e7c774515.png)



- Super simple start to building squash marker, built simplistic structure as seen here
- <img width="462" alt="Screenshot 2023-01-25 at 20 22 43" src="https://user-images.githubusercontent.com/3097647/214683160-f540b17d-90e2-4bd4-bd1f-c8ed1d7164fd.png">

## Future considerations
- Code readability, current switch values for `Scoring method` accept a boolean value, would be nice to make this more readable through the use of an enum 🤔
-  Will most definitely have to switch to using the Context API to make relevant data available across screens instead of passing props through several components (avoiding prop drilling & tight coupling of components)

#1 